### PR TITLE
Make byro-gemeinnuetzigkeit Python 3.5 compatible

### DIFF
--- a/byro_gemeinnuetzigkeit/donations.py
+++ b/byro_gemeinnuetzigkeit/donations.py
@@ -22,7 +22,7 @@ def generate_donation_receipt(member, year):
     donations = member.donations.filter(value_datetime__year=year).aggregate(donations=models.Sum('amount'))['donations'] or Decimal('0.00')
     address = member.address
     if (donations + fees) <= 0:
-        raise Exception(f'No donations or fees for {year}.')
+        raise Exception('No donations or fees for {year}.'.format(year=year))
 
     story = []
     _buffer = BytesIO()


### PR DESCRIPTION
Byro itself is python 3.5 compatible, see https://github.com/byro/byro/commit/dbe7071fb73191959e37383e4a8b71b4546e588e
This was the only f-string in byro-gemeinnuetzigkeit